### PR TITLE
Add convenience property fo NSNotFound-based range

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ You can also use this class to tranform individual points or other `NSRange`s. T
 
 ```swift
 // convenience
-static var zero
+static var zero: NSRange
+static var notFound: NSRange
 var max: Int
 
 // shifting

--- a/Rearrange/NSRange+Convenience.swift
+++ b/Rearrange/NSRange+Convenience.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 extension NSRange {
-    public static var zero = NSRange(location: 0, length: 0)
+    public static let zero = NSRange(location: 0, length: 0)
+    public static let notFound = NSRange(location: NSNotFound, length: 0)
 }
 
 extension NSRange {


### PR DESCRIPTION
Some search-based API produce `NSNotFound` locations. I have a ton of these in my app, maybe you want them, too :)

Converted the `var` to `let` to avoid mutations.