### PR TITLE
Added a `.mailmap` file to consolidate author names

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Matt Massicotte <85322+mattmassicotte@users.noreply.github.com>


### PR DESCRIPTION
It may be a little cheeky for me to assume you want to do this, but we talked about Rearrange on the SPI podcast this week and I noticed the duplicate name in our author detection.

![Screenshot 2023-07-27 at 12 45 27@2x](https://github.com/ChimeHQ/Rearrange/assets/5180/9ffe68bc-080c-4f83-8c75-7aab0467aa4d)
