### PR TITLE
Test non-empty IndexSet.limitSpanningRange, documenting why max is inside

### DIFF
--- a/Sources/Rearrange/IndexSet+NSRange.swift
+++ b/Sources/Rearrange/IndexSet+NSRange.swift
@@ -51,9 +51,9 @@ public extension IndexSet {
         return intersects(integersIn: elementRange)
     }
 
-    /// Returns a range starting at the minimum of the test and extending to the maximum
+    /// Returns a range encompassing the minimum and maximum value of the set (including the maximum, because `IndexSet` describes indices that are part of the range, not past-end positions).
     ///
-    /// This value will be nil if either min() or max() are nil
+    /// This value will be nil if either `min()` or `max()` are `nil`.
     var limitSpanningRange: NSRange? {
         guard let start = self.min(), let end = self.max() else {
             return nil

--- a/Sources/Rearrange/IndexSet+NSRange.swift
+++ b/Sources/Rearrange/IndexSet+NSRange.swift
@@ -51,7 +51,9 @@ public extension IndexSet {
         return intersects(integersIn: elementRange)
     }
 
-    /// Returns a range encompassing the minimum and maximum value of the set (including the maximum, because `IndexSet` describes indices that are part of the range, not past-end positions).
+    /// Returns a range encompassing the minimum and maximum value of the set.
+    ///
+    /// The resulting range includes both minimum and maximum boundaries of `self` because these describe indices that should be part of the range, not past-end positions.
     ///
     /// This value will be nil if either `min()` or `max()` are `nil`.
     var limitSpanningRange: NSRange? {

--- a/Tests/RearrangeTests/IndexSetExtenstionTests.swift
+++ b/Tests/RearrangeTests/IndexSetExtenstionTests.swift
@@ -17,7 +17,13 @@ class IndexSetExtenstionTests: XCTestCase {
         XCTAssertEqual(set.limitSpanningRange, NSRange(location: 0, length: 5))
     }
 
-    func testLimitSpanningRange() {
+    func testLimitSpanningRangeWithOneIndex() {
+        let set = IndexSet([42])
+
+        XCTAssertEqual(set.limitSpanningRange, NSRange(location: 42, length: 1))
+    }
+
+    func testLimitSpanningRangeWithMultipleIndices() {
         let set = IndexSet([1, 7, 3])
 
         XCTAssertEqual(set.limitSpanningRange, NSRange(1...7))

--- a/Tests/RearrangeTests/IndexSetExtenstionTests.swift
+++ b/Tests/RearrangeTests/IndexSetExtenstionTests.swift
@@ -17,6 +17,12 @@ class IndexSetExtenstionTests: XCTestCase {
         XCTAssertEqual(set.limitSpanningRange, NSRange(location: 0, length: 5))
     }
 
+    func testLimitSpanningRange() {
+        let set = IndexSet([1, 7, 3])
+
+        XCTAssertEqual(set.limitSpanningRange, NSRange(1...7))
+    }
+
     func testLimitSpanningRangeWithEmptySet() {
         let set = IndexSet()
 


### PR DESCRIPTION
Looking at the implementation, I wondered if `...` instead of `..<` was intentional -- but writing the test showed that, yes of course I want the largest element to be part of the range :)